### PR TITLE
update for gfortran/gcc 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ Makefile.cpu
 *.o
 *.a
 *~
+primme/int_redefine.h
+test_eigb
+test_eigb.out
+test_svd

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ test_eigb_i: mytt.a primme.a
 	ifort -O2 test_eigb.f90 mytt.a primme/primme.a -o test_eigb  $(LIB)
 
 test_eigb_g: mytt.a primme.a
-	gfortran -O3 test_eigb.f90 mytt.a primme/primme.a -o test_eigb  $(LIB)
+	gfortran $(FOPT) test_eigb.f90 mytt.a primme/primme.a -o test_eigb  $(LIB)
 
 test_svd_g: mytt.a 
-	gfortran -O3 test_svd.f90 mytt.a -o test_svd  $(LIB)
+	gfortran $(FOPT) test_svd.f90 mytt.a -o test_svd  $(LIB)
 
 
 .f.o:

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,11 +1,11 @@
 include Makefile.cpu
 # A preset for LAPACK with 8-byte integers and PIC (e.g. in MATLAB x64), GNU compiler
 ifeq ($(CPU),i8-gnu)
-      FOPT    = -fdefault-integer-8 -ffree-line-length-none -O3 -fPIC
+      FOPT    = -fdefault-integer-8 -ffree-line-length-none -O3 -fPIC -fallow-argument-mismatch
       FC   = gfortran
       LDR   = gfortran
       CC    = gcc
-      COPT = -O3 -fPIC
+      COPT = -O3 -fPIC $(CFLAGS)
       LIB   = -llapack -lblas -lgomp
       INTDEF = ""
 endif

--- a/gmres_3d.c
+++ b/gmres_3d.c
@@ -1,10 +1,11 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <f77blas.h>
 // extern void tt_adapt_als_mp_djac_apply_(char *ptype, long *rx1, long *n, long *rx2, double *jacs, double *x, double *y, double *work1);
 // extern void tt_adapt_als_mp_dbfun3_(long *rx1, long *m, long *rx2, long *ry1, long *n, long *ry2, long *ra1, long *ra2, double *phi1, double *A, double *phi2, double *x, double *y, double *res1, double *res2);
 extern void djac_apply(char *ptype, long *rx1, long *n, long *rx2, double *jacs, double *x, double *y, double *work1);
 extern void dbfun3(long *rx1, long *m, long *rx2, long *ry1, long *n, long *ry2, long *ra1, long *ra2, double *phi1, double *A, double *phi2, double *x, double *y, double *res1, double *res2);
-
-extern double dnrm2_(long *n, double *x, long *step);
-extern double ddot_(long *n, double *x, long *xstep, double *y, long *ystep);
 
 // #define djac_apply tt_adapt_als_mp_djac_apply_
 // #define dbfun3 tt_adapt_als_mp_dbfun3_


### PR DESCRIPTION
tested with openblas 3.9.1 on macOS 11 (with Homebrew)

I was able to build and run test_eigb and test_svd

This should address https://github.com/oseledets/tt-fort/issues/6